### PR TITLE
fix: #318 button styles in reports table

### DIFF
--- a/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
+++ b/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
@@ -19,7 +19,7 @@ $listLeftMargin: 20px;
 }
 
 .flatButton {
-  width: 125px;
+  width: 100px;
   height: 20px;
   padding: 0px;
 }

--- a/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
+++ b/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
@@ -19,7 +19,9 @@ $listLeftMargin: 20px;
 }
 
 .flatButton {
+  width: 125px;
   height: 20px;
+  padding: 0px;
 }
 
 .summaryText {

--- a/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
+++ b/mw-webapp/src/logic/wayPage/reportsTable/WayColumns.module.scss
@@ -28,9 +28,6 @@ $listLeftMargin: 20px;
   text-wrap: nowrap;
 }
 
-.cell {
-}
-
 .numberedList {
   width: calc(100% - $listLeftMargin);
   margin-left: $listLeftMargin;


### PR DESCRIPTION
![Screenshot 2023-12-16 213902](https://github.com/tritonJS826/masters-way/assets/103531486/3eb80f7c-6aab-4257-9457-2b4d56fcad00)
In WayColumns.module.scss exist class without styles. Should I delete it?
`.cell {
}`