### PR TITLE
fix: #428 fixed tooltip in app

### DIFF
--- a/mw-webapp/src/component/table/Table.module.scss
+++ b/mw-webapp/src/component/table/Table.module.scss
@@ -17,11 +17,6 @@ $cell-max-width: 600px;
   background: var(--primaryBackgroundColor);
   background-clip: padding-box;
   font-weight: bold;
-
-  // make createdAt fill minimum width
-  &:nth-child(1) {
-    width: 0;
-  }
 }
 
 .table td {

--- a/mw-webapp/src/component/tooltip/PositionTooltip.ts
+++ b/mw-webapp/src/component/tooltip/PositionTooltip.ts
@@ -25,7 +25,22 @@ export const enum PositionTooltip {
   BOTTOM = "bottom",
 
   /**
+   * Position Tooltip is below and left the cursor relative to the element
+   */
+  BOTTOM_LEFT = "bottomLeft",
+
+  /**
+   * Position Tooltip is below and right the cursor relative to the element
+   */
+  BOTTOM_RIGHT = "bottomRight",
+
+  /**
    * Position Tooltip is above and left the cursor relative to the element
    */
   TOP_LEFT = "topLeft",
+
+  /**
+   * Position Tooltip is above and right the cursor relative to the element
+   */
+  TOP_RIGHT = "topRight",
 }

--- a/mw-webapp/src/component/tooltip/Tooltip.module.scss
+++ b/mw-webapp/src/component/tooltip/Tooltip.module.scss
@@ -35,19 +35,32 @@ th .wrapper {
 }
 
 .right {
-  transform: translateY(-100%) translateX($tooltipMarginLeft);
-}
-
-// Don't delete empty style because it's one of default tooltip position className and can be change in the future
-.bottom {
+  transform: translateY(-100%) translateX($marginBig);
 }
 
 .left {
   transform: translateY(-100%) translateX(calc(-100% - $marginBig));
 }
 
+// Don't delete empty style because it's one of default tooltip position className and can be change in the future
+.bottom {
+}
+
+.bottomLeft {
+  transform: translateY(0) translateX(-50%);
+}
+
+.bottomRight {
+  transform: translateY(0) translateX(50%);
+  // transform: translateY(calc(0% - $marginBig)) translateX(50%);
+}
+
 .topLeft {
   transform: translateY(calc(-100% - $marginBig)) translateX(-50%);
+}
+
+.topRight {
+  transform: translateY(calc(-100% - $marginBig)) translateX(50%);
 }
 
 @keyframes tooltipAppear {

--- a/mw-webapp/src/component/tooltip/Tooltip.module.scss
+++ b/mw-webapp/src/component/tooltip/Tooltip.module.scss
@@ -19,6 +19,7 @@ th .wrapper {
   background-color: var(--tertiaryBackgroundColor);
   color: var(--primaryTextColor);
   cursor: pointer;
+  opacity: 0;
 }
 
 .target {
@@ -52,7 +53,6 @@ th .wrapper {
 
 .bottomRight {
   transform: translateY(0) translateX(50%);
-  // transform: translateY(calc(0% - $marginBig)) translateX(50%);
 }
 
 .topLeft {

--- a/mw-webapp/src/dictionary/AllUsersPageContent.json
+++ b/mw-webapp/src/dictionary/AllUsersPageContent.json
@@ -22,6 +22,28 @@
             "ru": "Всего",
             "en": "Total found"
         },
+        "columnTooltip": { 
+            "name": {
+                "ru": "Имя пользователя",
+                "en": "User's name"
+            },
+            "email": {
+                "ru": "Контакт поильзователя",
+                "en": "User's email"
+            },
+            "ownWays": {
+                "ru": "Количество путей для которых пользователь является владельцем",
+                "en": "Amount of ways for which the user is the owner"
+            },
+            "favoriteWays": {
+                "ru": "Количество любимых путей",
+                "en": "Amount of favorite ways"
+            },
+            "mentoringWays": {
+                "ru": "Количество путей для которых пользователь является ментором",
+                "en": "Amount of ways for which the user is the mentor"
+            }
+        },
         "column": {
             "name": {
                 "ru": "Пользователи",

--- a/mw-webapp/src/logic/usersTable/usersColumns.tsx
+++ b/mw-webapp/src/logic/usersTable/usersColumns.tsx
@@ -1,9 +1,11 @@
-import {createColumnHelper} from "@tanstack/react-table";
-import {Link} from "src/component/link/Link";
-import {UserPreview} from "src/model/businessModelPreview/UserPreview";
-import {pages} from "src/router/pages";
-import {LanguageService} from "src/service/LangauageService";
-import {Language} from "src/utils/LanguageWorker";
+import { createColumnHelper } from "@tanstack/react-table";
+import { Link } from "src/component/link/Link";
+import { PositionTooltip } from "src/component/tooltip/PositionTooltip";
+import { Tooltip } from "src/component/tooltip/Tooltip";
+import { UserPreview } from "src/model/businessModelPreview/UserPreview";
+import { pages } from "src/router/pages";
+import { LanguageService } from "src/service/LangauageService";
+import { Language } from "src/utils/LanguageWorker";
 import styles from "src/logic/usersTable/UserColumns.module.scss";
 
 const columnHelper = createColumnHelper<UserPreview>();
@@ -14,61 +16,119 @@ const columnHelper = createColumnHelper<UserPreview>();
  */
 export const getUsersColumns = (language: Language) => [
   columnHelper.accessor("name", {
-    header: LanguageService.allUsers.usersTable.column.name[language],
+    /**
+     * Header
+     */
+    header: () => (
+      <Tooltip
+        content={
+          LanguageService.allUsers.usersTable.columnTooltip.name[language]
+        }
+      >
+        {LanguageService.allUsers.usersTable.column.name[language]}
+      </Tooltip>
+    ),
 
     /**
      * Cell with clickable username that leads to user page
      */
-    cell: ({row}) => (
-      <Link path={pages.user.getPath({uuid: row.original.uuid})}>
-        {row.original.name}
+    cell: ({ row }) => (
+      <Link path={pages.user.getPath({ uuid: row.original.uuid })}>
+        <Tooltip position={PositionTooltip.TOP} content={row.original.name}>
+          {row.original.name}
+        </Tooltip>
       </Link>
     ),
   }),
   columnHelper.accessor("email", {
-    header: LanguageService.allUsers.usersTable.column.email[language],
+    /**
+     * Header
+     */
+    header: () => (
+      <Tooltip
+        content={LanguageService.allUsers.usersTable.columnTooltip.email[language]}
+      >
+        {LanguageService.allUsers.usersTable.column.email[language]}
+      </Tooltip>
+    ),
 
     /**
      * Cell user email
      */
-    cell: ({row}) => (
-      <span>
+    cell: ({ row }) => (
+      <Tooltip position={PositionTooltip.TOP} content={row.original.email}>
         {row.original.email}
-      </span>
+      </Tooltip>
     ),
   }),
   columnHelper.accessor("ownWays", {
-    header: LanguageService.allUsers.usersTable.column.ownWays[language],
+    /**
+     * Header
+     */
+    header: () => (
+      <Tooltip
+        content={
+          LanguageService.allUsers.usersTable.columnTooltip.ownWays[language]
+        }
+      >
+        {LanguageService.allUsers.usersTable.column.ownWays[language]}
+      </Tooltip>
+    ),
 
     /**
      * Cell with user's own ways
      */
-    cell: ({row}) => (
+    cell: ({ row }) => (
       <div className={styles.number}>
         {row.original.ownWays.length.toString()}
       </div>
     ),
   }),
   columnHelper.accessor("favoriteWays", {
-    header: LanguageService.allUsers.usersTable.column.favoriteWays[language],
+    /**
+     * Header
+     */
+    header: () => (
+      <Tooltip
+        content={
+          LanguageService.allUsers.usersTable.columnTooltip.favoriteWays[
+            language
+          ]
+        }
+      >
+        {LanguageService.allUsers.usersTable.column.favoriteWays[language]}
+      </Tooltip>
+    ),
 
     /**
      * Cell with user's favorite ways
      */
-    cell: ({row}) => (
+    cell: ({ row }) => (
       <div className={styles.number}>
         {row.original.favoriteWays.length.toString()}
       </div>
-
     ),
   }),
   columnHelper.accessor("mentoringWays", {
-    header: LanguageService.allUsers.usersTable.column.mentoringWays[language],
+    /**
+     * Header
+     */
+    header: () => (
+      <Tooltip
+        content={
+          LanguageService.allUsers.usersTable.columnTooltip.mentoringWays[
+            language
+          ]
+        }
+      >
+        {LanguageService.allUsers.usersTable.column.mentoringWays[language]}
+      </Tooltip>
+    ),
 
     /**
      * Cell with user's mentoring ways
      */
-    cell: ({row}) => (
+    cell: ({ row }) => (
       <div className={styles.number}>
         {row.original.mentoringWays.length.toString()}
       </div>

--- a/mw-webapp/src/logic/wayPage/reportsTable/ReportsTable.module.scss
+++ b/mw-webapp/src/logic/wayPage/reportsTable/ReportsTable.module.scss
@@ -1,3 +1,6 @@
 .positionTd {
   position: relative;
+  &:nth-child(1) {
+    width: 0;
+  }
 }

--- a/mw-webapp/src/logic/waysTable/waysColumns.tsx
+++ b/mw-webapp/src/logic/waysTable/waysColumns.tsx
@@ -127,7 +127,10 @@ export const getWaysColumns = (language: Language) => [
         <Link path={pages.way.getPath({uuid: row.original.uuid})}>
           {row.original.name}
         </Link>
-        <Tooltip content={renderMarkdown(row.original.goalDescription)}>
+        <Tooltip
+          content={renderMarkdown(row.original.goalDescription)}
+          position={PositionTooltip.BOTTOM}
+        >
           <div className={styles.shortCell}>
             {renderMarkdown(row.original.goalDescription)}
           </div>


### PR DESCRIPTION
- [x] waypage: fix tooltip on Date, fix tooltip on numbers in the table (time), align margins for all tooltips (add comment, add problem, check everywhere, metrics block etc.). Align in the whole app
- [x] statistics block does not react on change job time 
- [x] move goal tooltip above the goal (for example on ways page)
- [x] sorry, i added short columns for all table in project, could you apply this style only for appoipriate columns 
- [ ] wrong numbers in statistics block (for example totoa week and total 2weeks) check all, probably wrong intervals [2h]
- [x] add tooltip for all interactive elements, adjust all tooltips position (in the whole app, check twice it is very important) (add all 8 positions and use an appropriate)
- [ ] remove not required wrappers, learn flex box API, align goal singular metric