### PR TITLE
fix: #733 fix tooltip overlaps

### DIFF
--- a/mw-webapp/src/logic/wayPage/reportsTable/ReportsTable.module.scss
+++ b/mw-webapp/src/logic/wayPage/reportsTable/ReportsTable.module.scss
@@ -1,5 +1,4 @@
 .positionTd {
-  position: relative;
   &:nth-child(1) {
     width: 0;
   }


### PR DESCRIPTION
fixxed tooltip overlaps in reports table
![image](https://github.com/tritonJS826/masters-way/assets/112805668/b05e13ac-bdea-4387-95ce-1181c6f1b321)
![image](https://github.com/tritonJS826/masters-way/assets/112805668/ac564bc7-3dc5-411a-95cd-b83e1c3ed843)
