### PR TITLE
fix: #729 job breaks

### DIFF
--- a/mw-webapp/src/component/editableText/renderSpan.tsx
+++ b/mw-webapp/src/component/editableText/renderSpan.tsx
@@ -26,7 +26,7 @@ const renderEmptySpan = (placeholderSpanText?: string) => (
  * TODO: move to separate component, task #208
  */
 export const renderSpan = (value: string | number, isDone?: boolean, placeholderSpanText?: string) => (
-  (value === "")
+  (value.toString().trim() === "")
     ? renderEmptySpan(placeholderSpanText)
     : renderSpanWithValue(value, isDone)
 );


### PR DESCRIPTION
1. User's ways: job breaks down when string contains only spaces used as job name