### PR TITLE
style: #670 fix styles for sidebar on mobile 320px

### DIFF
--- a/mw-webapp/src/component/modal/ModalContent/ModalContent.module.scss
+++ b/mw-webapp/src/component/modal/ModalContent/ModalContent.module.scss
@@ -33,6 +33,10 @@ $modal-animation-time: 150ms;
   &:focus {
     outline: none;
   }
+
+  @media only screen and (max-width: $mediaWidthMobileMedium) {
+    padding: 0;
+  }
 }
 
 .closeButton {

--- a/mw-webapp/src/component/userCard/UserCard.module.scss
+++ b/mw-webapp/src/component/userCard/UserCard.module.scss
@@ -30,13 +30,7 @@ $userCardAdditionalHeight: 90px;
 }
 
 .likes {
-  align-items: center;
   color: var(--secondaryTextColor);
-  gap: $gapSmall;
-
-  @media (max-width: $mediaWidthMobileMedium) {
-    align-self: flex-end;
-  }
 }
 
 .icon {
@@ -46,15 +40,11 @@ $userCardAdditionalHeight: 90px;
 
 .nameLikes {
   align-items: start;
-  justify-content: space-between;
-
-  @media (max-width: $mediaWidthMobileMedium) {
-    flex-direction: column;
-  }
 }
 
 .nameGroup {
   overflow: hidden;
+  flex: 1;
   gap: $gapSmall;
   justify-items: start;
 }
@@ -100,8 +90,4 @@ $userCardAdditionalHeight: 90px;
 .cardLink {
   font-size: $fontSizeBig;
   text-decoration: none;
-}
-
-.avatarNameContainer {
-  width: 100%;
 }

--- a/mw-webapp/src/component/userCard/UserCard.module.scss
+++ b/mw-webapp/src/component/userCard/UserCard.module.scss
@@ -33,6 +33,10 @@ $userCardAdditionalHeight: 90px;
   align-items: center;
   color: var(--secondaryTextColor);
   gap: $gapSmall;
+
+  @media (max-width: $mediaWidthMobileMedium) {
+    align-self: flex-end;
+  }
 }
 
 .icon {
@@ -43,9 +47,14 @@ $userCardAdditionalHeight: 90px;
 .nameLikes {
   align-items: start;
   justify-content: space-between;
+
+  @media (max-width: $mediaWidthMobileMedium) {
+    flex-direction: column;
+  }
 }
 
 .nameGroup {
+  overflow: hidden;
   gap: $gapSmall;
   justify-items: start;
 }
@@ -62,15 +71,11 @@ $userCardAdditionalHeight: 90px;
 }
 
 .mail {
-  display: -webkit-box;
   overflow: hidden;
-  -webkit-box-orient: vertical;
   color: var(--secondaryTextColor);
   font-size: $fontSizeMedium;
   font-weight: bold;
-  -webkit-line-clamp: 1;
   text-overflow: ellipsis;
-  white-space: initial;
 }
 
 .userTags {
@@ -95,4 +100,8 @@ $userCardAdditionalHeight: 90px;
 .cardLink {
   font-size: $fontSizeBig;
   text-decoration: none;
+}
+
+.avatarNameContainer {
+  width: 100%;
 }

--- a/mw-webapp/src/component/userCard/UserCard.tsx
+++ b/mw-webapp/src/component/userCard/UserCard.tsx
@@ -9,7 +9,10 @@ import {Tooltip} from "src/component/tooltip/Tooltip";
 import {Skill} from "src/component/userCard/skill/Skill";
 import {VerticalContainer} from "src/component/verticalContainer/VerticalContainer";
 import {languageStore} from "src/globalStore/LanguageStore";
-import {UserNotSaturatedWay, UserTag} from "src/model/businessModelPreview/UserNotSaturatedWay";
+import {
+  UserNotSaturatedWay,
+  UserTag,
+} from "src/model/businessModelPreview/UserNotSaturatedWay";
 import {pages} from "src/router/pages";
 import {LanguageService} from "src/service/LanguageService";
 import {DateUtils} from "src/utils/DateUtils";
@@ -48,8 +51,7 @@ export const UserCard = observer((props: UserCardProps) => {
             key={skill.uuid}
             skillName={skill.name}
           />
-        ))
-        }
+        ))}
       </HorizontalContainer>
     );
   };
@@ -63,25 +65,23 @@ export const UserCard = observer((props: UserCardProps) => {
       <VerticalContainer className={styles.userCardContainer}>
         <VerticalContainer className={styles.mainInfo}>
           <HorizontalContainer className={styles.nameLikes}>
-            <HorizontalContainer className={styles.avatarNameContainer}>
-              <Avatar
-                alt={props.userPreview.name}
-                src={props.userPreview.imageUrl}
-                size={AvatarSize.BIG}
+            <Avatar
+              alt={props.userPreview.name}
+              src={props.userPreview.imageUrl}
+              size={AvatarSize.BIG}
+            />
+            <VerticalContainer className={styles.nameGroup}>
+              <Title
+                text={props.userPreview.name}
+                level={HeadingLevel.h3}
+                className={styles.title}
+                placeholder=""
               />
-              <VerticalContainer className={styles.nameGroup}>
-                <Title
-                  text={props.userPreview.name}
-                  level={HeadingLevel.h3}
-                  className={styles.title}
-                  placeholder=""
-                />
-                <p className={styles.mail}>
-                  {props.userPreview.email}
-                </p>
-              </VerticalContainer>
-            </HorizontalContainer>
-            <HorizontalContainer className={styles.likes}>
+              <p className={styles.mail}>
+                {props.userPreview.email}
+              </p>
+            </VerticalContainer>
+            <VerticalContainer className={styles.likes}>
               <Tooltip
                 position={PositionTooltip.BOTTOM}
                 content={LanguageService.allUsers.userCard.likes[language]}
@@ -93,7 +93,7 @@ export const UserCard = observer((props: UserCardProps) => {
                 />
                 {props.userPreview.favoriteForUsers}
               </Tooltip>
-            </HorizontalContainer>
+            </VerticalContainer>
           </HorizontalContainer>
           <Tooltip
             position={PositionTooltip.BOTTOM}
@@ -121,4 +121,3 @@ export const UserCard = observer((props: UserCardProps) => {
     </Link>
   );
 });
-

--- a/mw-webapp/src/component/userCard/UserCard.tsx
+++ b/mw-webapp/src/component/userCard/UserCard.tsx
@@ -63,7 +63,7 @@ export const UserCard = observer((props: UserCardProps) => {
       <VerticalContainer className={styles.userCardContainer}>
         <VerticalContainer className={styles.mainInfo}>
           <HorizontalContainer className={styles.nameLikes}>
-            <HorizontalContainer>
+            <HorizontalContainer className={styles.avatarNameContainer}>
               <Avatar
                 alt={props.userPreview.name}
                 src={props.userPreview.imageUrl}

--- a/mw-webapp/src/logic/wayPage/goalBlock/GoalBlock.module.scss
+++ b/mw-webapp/src/logic/wayPage/goalBlock/GoalBlock.module.scss
@@ -3,13 +3,13 @@
 $iconContainerSize: 25px;
 
 .goalSection {
+  flex-direction: column;
   flex-wrap: nowrap;
   flex-wrap: wrap;
   justify-content: space-between;
 }
 
 .goalDescription {
-  min-width: $minWidthBlock;
   max-width: $maxWidthBlock;
 
   textarea {

--- a/mw-webapp/src/styles/_variables.scss
+++ b/mw-webapp/src/styles/_variables.scss
@@ -47,7 +47,7 @@ $gapExtraLarge: 48px;
 // Widths and heights
 $iconSizeSmall: 15px;
 $iconSizeMedium: 25px;
-$minWidthBlock: 280px;
+$minWidthBlock: 252px;
 $maxWidthContainer: 1560px;
 $mediumWidthBlock: 350px;
 $maxWidthFullScreen: 1920px;


### PR DESCRIPTION
This PR contains style fixes that keep content from going beyond small screens (320px).
1. Goal description fits in its block. Removed min-width property and set flex-direction: column.
Before:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/95cfe71d-c834-4c38-ba33-d372c490f68f" width="300"/>

After:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/2dd3abec-797f-470b-981c-144e84f6e448" width="300"/>

2. Statistics and many other blocks fits on the screen. I reduced $minWidthBlock global variable from 280px to 252px.
Before:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/383db3f9-c5bc-4952-bc34-c20faeb83434" width="300"/>

After:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/1b05aafb-3c3d-4c71-b748-4da3cdb53872" width="300"/>

3. Fit 'email', 'name' and 'favories' button in a block on "All users" screen. Put avatar, name and 'favorites' in one flex container.
Before:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/8297db4e-5eee-4bbc-91ea-e50bf6db22b9" width="300"/>

After:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/b99aea84-6450-400a-9b1f-017ebd041313" width="300"/>

4. Fit statistics dialog on the screen. Removed paddings in the dialog on screens less than $mediaWidthMobileMedium.
Before:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/46ce74da-0c80-4a86-870b-05d0ed835028" width="300"/>

After:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/8e7964d3-8aa3-4a63-bc7d-785b3cc17377" width="300"/>




