### PR TITLE
fix: #978 Modals: broken modal paddings

### DIFF
--- a/mw-webapp/src/component/modal/ModalContent/ModalContent.module.scss
+++ b/mw-webapp/src/component/modal/ModalContent/ModalContent.module.scss
@@ -35,7 +35,7 @@ $modal-animation-time: 150ms;
   }
 
   @media only screen and (max-width: $mediaWidthMobileMedium) {
-    padding: 0;
+    padding: $paddingBig;
   }
 }
 

--- a/mw-webapp/src/logic/wayPage/wayStatistics/WayStatistic.module.scss
+++ b/mw-webapp/src/logic/wayPage/wayStatistics/WayStatistic.module.scss
@@ -6,4 +6,8 @@
   width: 100%;
   gap: $gapMedium;
   grid-template-columns: repeat(auto-fit, minmax($minWidthBlock, 1fr));
+
+  @media only screen and (max-width: $mediaWidthMobileMedium) {
+    padding: $paddingBig 4px;
+  }
 }

--- a/mw-webapp/src/logic/wayPage/wayStatistics/WayStatistic.module.scss
+++ b/mw-webapp/src/logic/wayPage/wayStatistics/WayStatistic.module.scss
@@ -8,6 +8,6 @@
   grid-template-columns: repeat(auto-fit, minmax($minWidthBlock, 1fr));
 
   @media only screen and (max-width: $mediaWidthMobileMedium) {
-    padding: $paddingBig 4px;
+    padding: $paddingBig $paddingSmall;
   }
 }


### PR DESCRIPTION
This PR contains fixes related to adding padding to modals on small screens (#978).
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/efe79333-e6c9-4266-a074-99f1c3b07a75" width="300" />

As adding padding to modals breaks statistics in modals, so I also touched this place. Now it looks like this:
<img src="https://github.com/tritonJS826/masters-way/assets/8752900/7d8487a0-af48-4d66-9709-8a37c848f6ce" width="300" />

 