### PR TITLE
fix: #930 ok button is enabled when tag name input is empty

### DIFF
--- a/mw-webapp/src/component/button/Button.module.scss
+++ b/mw-webapp/src/component/button/Button.module.scss
@@ -32,11 +32,6 @@
   &:active {
     background-color: var(--primaryBgBtnActiveColor);
   }
-
-  &:disabled {
-    background-color: revert;
-    color: revert;
-  }
 }
 
 .secondary {

--- a/mw-webapp/src/component/button/Button.module.scss
+++ b/mw-webapp/src/component/button/Button.module.scss
@@ -12,6 +12,11 @@
   font-size: $fontSizeBig;
   gap: $gapSmall;
   transition-duration: $primaryTransitionDuration;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: $disableOpacity;
+  }
 }
 
 .primary {
@@ -19,13 +24,18 @@
   background-color: var(--generalPrimaryColor);
   color: var(--secondaryTextColor);
 
-  &:hover {
+  &:hover:enabled {
     background-color: var(--primaryBgBtnHoverColor);
     cursor: pointer;
   }
 
   &:active {
     background-color: var(--primaryBgBtnActiveColor);
+  }
+
+  &:disabled {
+    background-color: revert;
+    color: revert;
   }
 }
 
@@ -85,10 +95,6 @@
     background-color: var(--primaryBgColor);
     color: var(--generalPrimaryColor);
   }
-}
-
-.disabled {
-  opacity: $disableOpacity;
 }
 
 .superSpecialBeautifulButton {

--- a/mw-webapp/src/component/button/Button.tsx
+++ b/mw-webapp/src/component/button/Button.tsx
@@ -82,16 +82,16 @@ export interface ButtonProps {
  * Button component
  */
 export const Button = forwardRef((props: ButtonProps, ref?: ForwardedRef<HTMLButtonElement>) => {
-  const [isDisabled, setIssDisabled] = useState(props.isDisabled ?? false);
+  const [isBlocked, setIsBlocked] = useState(false);
 
   /**
    * Handler on button click
    * If callback promise than button will be inactive until promise resolved
    */
   const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    setIssDisabled(true);
+    setIsBlocked(true);
     await Promise.resolve(props.onClick(event));
-    setIssDisabled(false);
+    setIsBlocked(false);
   };
 
   return (
@@ -100,12 +100,11 @@ export const Button = forwardRef((props: ButtonProps, ref?: ForwardedRef<HTMLBut
       className={clsx(
         styles.button,
         styles[props.buttonType ?? ButtonType.SECONDARY],
-        {[styles.disabled]: isDisabled},
         props.className,
       )}
       onClick={handleClick}
       data-cy={props.dataCy}
-      disabled={isDisabled}
+      disabled={isBlocked || props.isDisabled}
     >
       {props.value}
       {props.icon}

--- a/mw-webapp/src/component/modal/PromptModalContent.tsx
+++ b/mw-webapp/src/component/modal/PromptModalContent.tsx
@@ -89,6 +89,7 @@ export const PromptModalContent = (props: PromptModalContentProps) => {
             value={props.okButtonValue}
             onClick={() => props.onOk(inputValue)}
             buttonType={ButtonType.PRIMARY}
+            isDisabled={inputValue.trim() === ""}
           />
         </DialogClose>
       </HorizontalContainer>


### PR DESCRIPTION
This PR contains the following changes:
- disable "Ok" button when the "tag name" input field is empty;
- fix the issue with initializing `isDisabled` state from props.