### PR TITLE
fix: #649 Center text in a tag

### DIFF
--- a/mw-webapp/src/component/tag/Tag.module.scss
+++ b/mw-webapp/src/component/tag/Tag.module.scss
@@ -2,13 +2,6 @@
 
 .tagContainer {
   position: relative;
-  display: inline-block;
-  padding: 0;
-  border: none;
-  background: none;
-  color: inherit;
-  font: inherit;
-  text-decoration: underline;
 
   .cross {
     visibility: hidden;
@@ -24,7 +17,10 @@
 }
 
 .tag {
-  display: inline-block;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
   border: 1px solid var(--primaryStrokeColor);
   border-radius: $tagBorderRadius;
   color: var(--primaryTextColor);
@@ -34,10 +30,10 @@
   overflow: hidden;
   max-width: $minWidthBlock;
   height: 40px;
-  padding: $paddingMedium;
   background-color: var(--secondaryBgColor);
   color: var(--primaryTextColor);
   font-size: $fontSizeBig;
+  padding-inline: $paddingMedium;
   text-overflow: ellipsis;
   text-wrap: nowrap;
 }

--- a/mw-webapp/src/component/tag/Tag.module.scss
+++ b/mw-webapp/src/component/tag/Tag.module.scss
@@ -18,7 +18,6 @@
 
 .tag {
   display: flex;
-  flex-wrap: nowrap;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--primaryStrokeColor);


### PR DESCRIPTION
Text is aligned in tags.

<img src="https://github.com/tritonJS826/masters-way/assets/8752900/86427c4a-00fc-44fe-a88d-1b2ee4272995" width="500"/>