### PR TITLE
fix: #984 Sidebar doesn’t close after clicking on logo

### DIFF
--- a/mw-webapp/src/component/link/Link.tsx
+++ b/mw-webapp/src/component/link/Link.tsx
@@ -28,6 +28,11 @@ interface LinkProps {
    * @default false
    */
   isNewTab?: boolean;
+
+  /**
+   * Callback triggered on Link click
+   */
+  onClick?: () => void;
 }
 
 /**
@@ -41,6 +46,7 @@ export const Link = (props: PropsWithChildren<LinkProps>) => {
       className={clsx(styles.link, props.className)}
       to={props.path}
       data-cy={props.dataCy}
+      onClick={props.onClick}
       {...externalLinkAttributes}
     >
       {props.children}

--- a/mw-webapp/src/component/sidebar/Sidebar.cy.tsx
+++ b/mw-webapp/src/component/sidebar/Sidebar.cy.tsx
@@ -9,6 +9,7 @@ const SIDEBAR_CY = {
     dataCyOverlay: "overlay",
     dataCyClose: "close",
     dataCyContent: "content",
+    dataCyLogo: "logo",
   },
 };
 
@@ -19,6 +20,15 @@ const SIDEBAR_TRIGGER = (
   />);
 
 const SIDEBAR_LINKS: MenuItemLink[] = [
+  {
+    path: "/",
+    value: "",
+    icon: <img
+      width="5px"
+      height="5px"
+      data-cy={SIDEBAR_CY.dataCyContent.dataCyLogo}
+    />,
+  },
   {
     path: "/",
     value: "Home",
@@ -83,4 +93,12 @@ describe("Sidebar component", () => {
       .should("not.exist");
   });
 
+  it("should sidebar be closed when click logo", () => {
+    cy.get(getDataCy(SIDEBAR_CY.dataCyTrigger))
+      .click();
+    cy.get(getDataCy(SIDEBAR_CY.dataCyContent.dataCyLogo))
+      .click();
+    cy.get(getDataCy(SIDEBAR_CY.dataCyContent.dataCyContent))
+      .should("not.exist");
+  });
 });

--- a/mw-webapp/src/component/sidebar/Sidebar.tsx
+++ b/mw-webapp/src/component/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, useState} from "react";
+import {ReactElement, useCallback, useState} from "react";
 import {Root as DialogRoot} from "@radix-ui/react-dialog";
 import {HorizontalContainer} from "src/component/horizontalContainer/HorizontalContainer";
 import {Link} from "src/component/link/Link";
@@ -105,33 +105,34 @@ interface SidebarProps {
 }
 
 /**
- * Renders navigation links based on the provided navigationLinks array.
- */
-const renderNavigationLinks = (navigationLinks: (MenuItemLink)[]) => {
-  return navigationLinks.map((item) => (
-    !item.isHidden && (
-      <HorizontalContainer
-        key={item.value}
-        className={styles.menuItem}
-      >
-        <Link
-          path={item.path}
-          className={styles.menuItemLink}
-          dataCy={item.dataCy}
-        >
-          {item.icon}
-          {item.value}
-        </Link>
-      </HorizontalContainer>
-    )
-  ));
-};
-
-/**
  * Sidebar component
  */
 export const Sidebar = (props: SidebarProps) => {
   const [open, setOpen] = useState(false);
+
+  /**
+   * Renders navigation links based on the provided navigationLinks array.
+   */
+  const renderNavigationLinks = useCallback((navigationLinks: (MenuItemLink)[]) => {
+    return navigationLinks.map((item) => (
+      !item.isHidden && (
+        <HorizontalContainer
+          key={item.value}
+          className={styles.menuItem}
+        >
+          <Link
+            path={item.path}
+            className={styles.menuItemLink}
+            dataCy={item.dataCy}
+            onClick={() => setOpen(false)}
+          >
+            {item.icon}
+            {item.value}
+          </Link>
+        </HorizontalContainer>
+      )
+    ));
+  }, [styles, setOpen]);
 
   return (
     <DialogRoot
@@ -144,7 +145,6 @@ export const Sidebar = (props: SidebarProps) => {
 
       <SidebarContent
         dataCyContent={props.cy?.dataCyContent}
-        onLinkClick={() => setOpen(false)}
         className={styles.sidebarContent}
       >
         <div className={styles.navSidebarContent}>

--- a/mw-webapp/src/component/sidebar/Sidebar.tsx
+++ b/mw-webapp/src/component/sidebar/Sidebar.tsx
@@ -144,7 +144,7 @@ export const Sidebar = (props: SidebarProps) => {
 
       <SidebarContent
         dataCyContent={props.cy?.dataCyContent}
-        onClick={() => setOpen(false)}
+        onLinkClick={() => setOpen(false)}
         className={styles.sidebarContent}
       >
         <div className={styles.navSidebarContent}>

--- a/mw-webapp/src/component/sidebar/SidebarContent/SidebarContent.tsx
+++ b/mw-webapp/src/component/sidebar/SidebarContent/SidebarContent.tsx
@@ -17,11 +17,6 @@ import styles from "src/component/sidebar/SidebarContent/SidebarContent.module.s
 interface SidebarContentProps extends PropsWithChildren {
 
   /**
-   * Callback triggered on SidebarContent click
-   */
-  onLinkClick: () => void;
-
-  /**
    * Data attribute for cypress testing
    */
   dataCyContent?: CyContent;
@@ -37,22 +32,6 @@ interface SidebarContentProps extends PropsWithChildren {
  * A container for the content to be displayed within a Sidebar.
  */
 export const SidebarContent = (props: SidebarContentProps) => {
-
-  /**
-   * Handle onClick event
-   */
-  const onClickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
-    let target: HTMLElement | null = event.target as HTMLElement;
-
-    while (target && target !== event.currentTarget) {
-      if (target instanceof HTMLAnchorElement) {
-        props.onLinkClick();
-        break;
-      }
-      target = target.parentElement;
-    }
-  };
-
   return (
     <DialogPortal>
       <DialogOverlay
@@ -62,7 +41,6 @@ export const SidebarContent = (props: SidebarContentProps) => {
       <DialogContent
         data-cy={props.dataCyContent?.dataCyContent}
         className={clsx(styles.dialogContent, props.className)}
-        onClick={onClickHandler}
       >
         {props.children}
         <DialogClose asChild>

--- a/mw-webapp/src/component/sidebar/SidebarContent/SidebarContent.tsx
+++ b/mw-webapp/src/component/sidebar/SidebarContent/SidebarContent.tsx
@@ -19,7 +19,7 @@ interface SidebarContentProps extends PropsWithChildren {
   /**
    * Callback triggered on SidebarContent click
    */
-  onClick: () => void;
+  onLinkClick: () => void;
 
   /**
    * Data attribute for cypress testing
@@ -42,8 +42,14 @@ export const SidebarContent = (props: SidebarContentProps) => {
    * Handle onClick event
    */
   const onClickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target instanceof HTMLAnchorElement) {
-      props.onClick();
+    let target: HTMLElement | null = event.target as HTMLElement;
+
+    while (target && target !== event.currentTarget) {
+      if (target instanceof HTMLAnchorElement) {
+        props.onLinkClick();
+        break;
+      }
+      target = target.parentElement;
     }
   };
 


### PR DESCRIPTION
This PR contains the following changes:
- The sidebar closes when clicking on logo and navigation icons;
- Added a test to close the sidebar when the logo is clicked.

Bug root cause:
event.target is not always HTMLAnchorElement, so when clicking on an icon, image event.target is `<img>`.

Resolves #984 