### PR TITLE
fix: #1039 fit progress data in a line

### DIFF
--- a/mw-webapp/src/component/progressBar/ProgressBar.module.scss
+++ b/mw-webapp/src/component/progressBar/ProgressBar.module.scss
@@ -33,4 +33,5 @@ $progressBarContainerHeight: 4px;
   justify-content: space-between;
   color: var(--primaryTextColor);
   line-height: $lineHeightPrimary;
+  white-space: nowrap;
 }


### PR DESCRIPTION
PR contains the fix when data doesn't fit in "Status" column.

<img src="https://github.com/tritonJS826/masters-way/assets/8752900/731d7ce3-26d2-4426-a279-db2e38c92cd2" width="500" />

Resolves #1039 