### PR TITLE
feat: #1057 Align design for Accordion component

### DIFF
--- a/mw-webapp/src/assets/icons/MinusIcon.tsx
+++ b/mw-webapp/src/assets/icons/MinusIcon.tsx
@@ -1,0 +1,26 @@
+import {IconProps} from "src/component/icon/Icon";
+
+/**
+ * Minus icon
+ */
+export const MinusIcon = (props: IconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={props.className}
+      data-cy={props.dataCy}
+    >
+      <line
+        x1="5"
+        y1="12"
+        x2="19"
+        y2="12"
+      />
+    </svg>
+  );
+};

--- a/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
@@ -1,5 +1,7 @@
 @import "src/styles/variables";
 
+$textLineHeight: 1.3;
+
 .accordionContent {
   overflow: hidden;
 
@@ -13,7 +15,8 @@
 }
 
 .accordionContentText {
-  padding: 15px 20px;
+  padding: $paddingSmall 0 $paddingMedium 0;
+  line-height: $textLineHeight;
 }
 
 @keyframes slideDown {
@@ -22,13 +25,13 @@
   }
 
   to {
-    height: 47px;
+    height: var(--radix-collapsible-content-height);
   }
 }
 
 @keyframes slideUp {
   from {
-    height: 47px;
+    height: var(--radix-collapsible-content-height);
   }
 
   to {

--- a/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
@@ -1,6 +1,5 @@
 @import "src/styles/variables";
 
-$textLineHeight: 1.3;
 
 .accordionContent {
   overflow: hidden;

--- a/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionContent/AccordionContent.module.scss
@@ -15,7 +15,7 @@
 
 .accordionContentText {
   padding: $paddingSmall 0 $paddingMedium 0;
-  line-height: $textLineHeight;
+  line-height: $lineHeightPrimary;
 }
 
 @keyframes slideDown {

--- a/mw-webapp/src/component/accordion/AccordionItem/AccordionItem.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionItem/AccordionItem.module.scss
@@ -1,6 +1,6 @@
+@import "src/styles/variables";
+
 .accordionItem {
-  overflow: hidden;
-  border-bottom: 1px solid var(--secondaryStrokeColor);
-  margin-top: 1px;
+  border-bottom: $primaryBorder solid var(--secondaryStrokeColor);
   color: var(--secondaryTextColor);
 }

--- a/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
@@ -1,40 +1,51 @@
 @import "src/styles/variables";
 
+$accordionMinHeight: 60px;
+
 .accordionHeader {
   display: flex;
-  margin: 0;
+  min-height: $accordionMinHeight;
+  align-items: flex-end;
 }
 
-.accordionChevron {
+.icon {
   flex-shrink: 0;
-  transition: transform 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  stroke: var(--secondaryStrokeColor);
 }
 
 .accordionTrigger {
   display: flex;
-  min-height: 45px;
   flex: 1;
   align-items: center;
   justify-content: space-between;
-  padding: $paddingExtraMedium;
+  padding: $paddingSmall 0;
   border: none;
   background-color: transparent;
   color: var(--secondaryTextColor);
-  font-size: 15px;
+  cursor: pointer;
+  font-family: inherit;
   font-size: $fontSizeBig;
-  line-height: 1;
+  font-weight: $fontWeightBold;
   text-align: left;
+  transition-duration: $elementHoverTransition;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 5%);
+    background-color: var(--hoverBgColor);
   }
 
-  &[data-state="open"] {
-    background-color: var(--generalPrimaryColor);
-    color: var(--secondaryTextColor);
+  &[data-state="open"] > .minusIcon {
+    display: block;
   }
 
-  &[data-state="open"] > .accordionChevron {
-    transform: rotate(180deg);
+  &[data-state="open"] > .plusIcon {
+    display: none;
+  }
+
+  &[data-state="closed"] > .minusIcon {
+    display: none;
+  }
+
+  &[data-state="closed"] > .plusIcon {
+    display: block;
   }
 }

--- a/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
@@ -26,6 +26,7 @@ $accordionMinHeight: 60px;
   font-family: inherit;
   font-size: $fontSizeBig;
   font-weight: $fontWeightBold;
+  gap: $gapSmall;
   text-align: left;
   transition-duration: $elementHoverTransition;
 

--- a/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
+++ b/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss
@@ -28,9 +28,10 @@ $accordionMinHeight: 60px;
   font-weight: $fontWeightBold;
   gap: $gapSmall;
   text-align: left;
-  transition-duration: $elementHoverTransition;
+  transition: all $elementHoverTransition ease;
 
   &:hover {
+    padding-left: $paddingExtraBig;
     background-color: var(--hoverBgColor);
   }
 

--- a/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.tsx
+++ b/mw-webapp/src/component/accordion/AccordionTrigger/AccordionTrigger.tsx
@@ -2,7 +2,8 @@ import {
   Header as RadixAccordionHeader,
   Trigger as RadixAccordionTrigger,
 } from "@radix-ui/react-accordion";
-import {ChevronDownIcon} from "@radix-ui/react-icons";
+import clsx from "clsx";
+import {Icon, IconSize} from "src/component/icon/Icon";
 import styles from "src/component/accordion/AccordionTrigger/AccordionTrigger.module.scss";
 
 /**
@@ -33,10 +34,18 @@ export const AccordionTrigger = (props: AccordionTriggerProps) => {
     >
       <RadixAccordionTrigger className={styles.accordionTrigger}>
         {props.child}
-        <ChevronDownIcon
-          className={styles.accordionChevron}
-          aria-hidden
-        />
+        <>
+          <Icon
+            size={IconSize.MEDIUM}
+            name={"PlusIcon"}
+            className={clsx(styles.icon, styles.plusIcon)}
+          />
+          <Icon
+            size={IconSize.MEDIUM}
+            name={"MinusIcon"}
+            className={clsx(styles.icon, styles.minusIcon)}
+          />
+        </>
       </RadixAccordionTrigger>
     </RadixAccordionHeader>
   );

--- a/mw-webapp/src/component/icon/Icon.cy.tsx
+++ b/mw-webapp/src/component/icon/Icon.cy.tsx
@@ -43,7 +43,7 @@ describe("Icon component", () => {
 
   it("should be render medium size", () => {
     cy.mount(createTestIcon({name: ICON, size: IconSize.MEDIUM}));
-    cy.get(getDataCy(ICON_CY)).invoke("css", "width").should("match", /25.*px/);
+    cy.get(getDataCy(ICON_CY)).invoke("css", "width").should("match", /24.*px/);
     cy.get(getDataCy(ICON_CY)).should("have.class", styles[IconSize.MEDIUM]);
   });
   it("should be render small size", () => {

--- a/mw-webapp/src/component/icon/Icon.tsx
+++ b/mw-webapp/src/component/icon/Icon.tsx
@@ -10,6 +10,7 @@ import {GlobeIcon} from "src/assets/icons/GlobeIcon";
 import {GridViewIcon} from "src/assets/icons/GridViewIcon";
 import {HomeIcon} from "src/assets/icons/HomeIcon";
 import {LinkedinIcon} from "src/assets/icons/LinkedinIcon";
+import {MinusIcon} from "src/assets/icons/MinusIcon";
 import {MoonIcon} from "src/assets/icons/MoonIcon";
 import {MoreVertical} from "src/assets/icons/MoreVertical";
 import {PlusIcon} from "src/assets/icons/PlusIcon";
@@ -74,6 +75,11 @@ export const IconDictionary = {
    * Plus icon
    */
   PlusIcon: (params: IconProps) => <PlusIcon {...params} />,
+
+  /**
+   * Minus icon
+   */
+  MinusIcon: (params: IconProps) => <MinusIcon {...params} />,
 
   /**
    * MoreVertical icon

--- a/mw-webapp/src/globalStore/ThemeStore.ts
+++ b/mw-webapp/src/globalStore/ThemeStore.ts
@@ -40,6 +40,10 @@ const themedVariables: Record<string, Record<Theme, string>> = {
     [Theme.DARK]: "#686085",
     [Theme.LIGHT]: "#F2EFF9",
   },
+  hoverBgColor: {
+    [Theme.DARK]: "#A8A1DD",
+    [Theme.LIGHT]: "#A8A1DD",
+  },
   // Sidebar and footer and shadow for notebook (homePage)
   quaternaryBgColor: {
     [Theme.DARK]: "#0B0322",

--- a/mw-webapp/src/logic/aboutProjectPage/AboutProjectPage.module.scss
+++ b/mw-webapp/src/logic/aboutProjectPage/AboutProjectPage.module.scss
@@ -2,6 +2,7 @@
 
 // Temporal bottom padding while wave block is not exist
 $aboutBlockPadding: 230px 0;
+$accordionMaxWidth: 1032px;
 
 .title {
   text-align: center;
@@ -68,5 +69,6 @@ $aboutBlockPadding: 230px 0;
 
 .accordion {
   width: 100%;
-  max-width: $maxWidthContainer;
+  max-width: calc($accordionMaxWidth + 2 * $paddingMedium);
+  padding: 0 $paddingMedium;
 }

--- a/mw-webapp/src/styles/_variables.scss
+++ b/mw-webapp/src/styles/_variables.scss
@@ -69,7 +69,7 @@ $gapExtraLarge: 48px;
 
 // Widths and heights
 $iconSizeSmall: 16px;
-$iconSizeMedium: 25px;
+$iconSizeMedium: 24px;
 $minWidthBlock: 248px;
 $maxWidthContainer: 1560px;
 $mediumWidthBlock: 350px;


### PR DESCRIPTION
Aligned the design for Accordion component.

<img src="https://github.com/tritonJS826/masters-way/assets/8752900/1d6f2426-0f28-44de-aa3c-3f6bea4384b6" width="700" />

 P.S. I changed "iconSizeMedium" from 25px to 24px global size, as 25px of size doesn't exist in the design, but 24px does (as the designer said).

