### PR TITLE
feat: #989 add accessibility in buttons on Home page [Pavel Kladkevich]

### DIFF
--- a/mw-webapp/src/component/sidebar/SidebarTrigger/SidebarTrigger.tsx
+++ b/mw-webapp/src/component/sidebar/SidebarTrigger/SidebarTrigger.tsx
@@ -1,5 +1,6 @@
 import {ForwardedRef, forwardRef, PropsWithChildren} from "react";
 import {Trigger as DialogTrigger} from "@radix-ui/react-dialog";
+import {headerAccessIds} from "cypress/accessIds/headerAccessIds";
 
 /**
  * SidebarTrigger props
@@ -25,6 +26,7 @@ export const SidebarTrigger = forwardRef((props: PropsWithChildren<SidebarTrigge
       <div
         ref={ref}
         role="button"
+        aria-label={headerAccessIds.burgerMenu}
       >
         {props.children}
       </div>

--- a/mw-webapp/src/component/sidebar/SidebarTrigger/SidebarTrigger.tsx
+++ b/mw-webapp/src/component/sidebar/SidebarTrigger/SidebarTrigger.tsx
@@ -1,6 +1,5 @@
 import {ForwardedRef, forwardRef, PropsWithChildren} from "react";
 import {Trigger as DialogTrigger} from "@radix-ui/react-dialog";
-import {headerAccessIds} from "cypress/accessIds/headerAccessIds";
 
 /**
  * SidebarTrigger props
@@ -26,7 +25,6 @@ export const SidebarTrigger = forwardRef((props: PropsWithChildren<SidebarTrigge
       <div
         ref={ref}
         role="button"
-        aria-label={headerAccessIds.burgerMenu}
       >
         {props.children}
       </div>

--- a/mw-webapp/src/component/themeSwitcher/ThemeSwitcher.tsx
+++ b/mw-webapp/src/component/themeSwitcher/ThemeSwitcher.tsx
@@ -78,6 +78,7 @@ export const ThemeSwitcher = (props: ThemeSwitcherProps) => {
         className={clsx(styles.iconWrapper, props.className)}
         onClick={onChangeTheme}
         data-cy={props.dataCy}
+        aria-label={props.dataCy}
       >
         <Icon
           size={IconSize.MEDIUM}

--- a/mw-webapp/src/component/themeSwitcher/ThemeSwitcher.tsx
+++ b/mw-webapp/src/component/themeSwitcher/ThemeSwitcher.tsx
@@ -78,7 +78,7 @@ export const ThemeSwitcher = (props: ThemeSwitcherProps) => {
         className={clsx(styles.iconWrapper, props.className)}
         onClick={onChangeTheme}
         data-cy={props.dataCy}
-        aria-label={props.dataCy}
+        aria-label={getDescriptionForTheme(props.theme, props.language)}
       >
         <Icon
           size={IconSize.MEDIUM}


### PR DESCRIPTION
Add aria-label to theme switch button and sidebar button.
The buttons that have text value do not require aria-label. 