### PR TITLE
fix: #749 fixed labels statistic status bars

### DIFF
--- a/mw-webapp/src/component/chart/blockChart/BarChart.tsx
+++ b/mw-webapp/src/component/chart/blockChart/BarChart.tsx
@@ -67,6 +67,8 @@ export const BarChart = observer((props: BarChartProps) => {
     indexAxis: "y" as const,
     scales: {
       x: {
+        min: 0,
+        max: dataSet.reduce((accum, item) => (accum + item.data[0]), 0),
         stacked: true,
         display: false,
       },
@@ -86,6 +88,8 @@ export const BarChart = observer((props: BarChartProps) => {
         text: "",
       },
     },
+    maintainAspectRatio: false,
+    responsive: true,
   };
 
   return (


### PR DESCRIPTION
This PR solves the problem of incomplete filling of the statistics strip of the assigned width.
It was:
![image](https://github.com/tritonJS826/masters-way/assets/102153384/4dcf4fcf-7ca3-4a45-ac39-c7ff4ac32f3c)

Become:
![image](https://github.com/tritonJS826/masters-way/assets/102153384/7fa9c7f7-ea92-4dc2-9525-0604ef301017)
